### PR TITLE
feat: support multiple lockboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Create cloud function with lockbox secret, list of scaling policies and specific trigger type. 
+- Create cloud function with lockbox secret, list of scaling policies and specific trigger type.
 - Integration with VPC can be added to cloud function.
 - Options for creating service account and/or logging group for the function.
 - Mounting the bucket for cloud function.
@@ -260,9 +260,9 @@ export TF_VAR_lockbox_secret_value=<yc-value>
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.11.2 |
-| <a name="provider_yandex"></a> [yandex](#provider\_yandex) | 0.123.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.13.1 |
+| <a name="provider_yandex"></a> [yandex](#provider\_yandex) | 0.162.0 |
 
 ## Modules
 
@@ -292,35 +292,36 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_choosing_trigger_type"></a> [choosing\_trigger\_type](#input\_choosing\_trigger\_type) | Choosing type for cloud function trigger. | `string` | n/a | yes |
-| <a name="input_create_trigger"></a> [create\_trigger](#input\_create\_trigger) | Create trigger for Cloud Function (true) or not (false).<br>    If `true` parameter `choosing_trigger_type` must not be empty string.<br>    If `false` trigger `yc_trigger` will not be created for Cloud Function. | `bool` | `false` | no |
+| <a name="input_create_trigger"></a> [create\_trigger](#input\_create\_trigger) | Create trigger for Cloud Function (true) or not (false).<br/>    If `true` parameter `choosing_trigger_type` must not be empty string.<br/>    If `false` trigger `yc_trigger` will not be created for Cloud Function. | `bool` | `false` | no |
 | <a name="input_entrypoint"></a> [entrypoint](#input\_entrypoint) | Entrypoint for cloud function yc-function-example. | `string` | `"handler.sh"` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | A set of key/value environment variables for Yandex Cloud Function from tf-module | `map(string)` | <pre>{<br>  "name": "John",<br>  "surname": "Wick"<br>}</pre> | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | A set of key/value environment variables for Yandex Cloud Function from tf-module | `map(string)` | <pre>{<br/>  "name": "John",<br/>  "surname": "Wick"<br/>}</pre> | no |
 | <a name="input_environment_variable"></a> [environment\_variable](#input\_environment\_variable) | Function's environment variable in which secret's value will be stored. | `string` | `"ENV_VARIABLE"` | no |
 | <a name="input_execution_timeout"></a> [execution\_timeout](#input\_execution\_timeout) | Execution timeout in seconds for cloud function yc-function-example. | `number` | `10` | no |
 | <a name="input_existing_log_group_id"></a> [existing\_log\_group\_id](#input\_existing\_log\_group\_id) | Existing logging group id. | `string` | `null` | no |
+| <a name="input_existing_secrets"></a> [existing\_secrets](#input\_existing\_secrets) | list of existing Lockbox secrets values for cloud function. | <pre>list(object({<br/>    id                   = string<br/>    key                  = string<br/>    version_id           = string<br/>    environment_variable = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_existing_service_account_id"></a> [existing\_service\_account\_id](#input\_existing\_service\_account\_id) | Existing IAM service account id. | `string` | `null` | no |
 | <a name="input_existing_service_account_name"></a> [existing\_service\_account\_name](#input\_existing\_service\_account\_name) | Existing IAM service account name. | `string` | `null` | no |
 | <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | The ID of the folder that the cloud function yc-function-example belongs to. | `string` | `null` | no |
 | <a name="input_lockbox_secret_key"></a> [lockbox\_secret\_key](#input\_lockbox\_secret\_key) | Lockbox secret key for cloud function yc-function-example. | `string` | n/a | yes |
 | <a name="input_lockbox_secret_value"></a> [lockbox\_secret\_value](#input\_lockbox\_secret\_value) | Lockbox secret value for cloud function yc-function-example. | `string` | n/a | yes |
-| <a name="input_logging"></a> [logging](#input\_logging) | Trigger type of logging. | <pre>object({<br>    group_id       = string<br>    resource_ids   = optional(list(string))<br>    resource_types = optional(list(string), ["serverless.function"])<br>    levels         = optional(list(string), ["INFO"])<br>    batch_cutoff   = number<br>    batch_size     = number<br>    stream_names   = optional(list(string))<br>  })</pre> | <pre>{<br>  "batch_cutoff": 1,<br>  "batch_size": 1,<br>  "group_id": null<br>}</pre> | no |
+| <a name="input_logging"></a> [logging](#input\_logging) | Trigger type of logging. | <pre>object({<br/>    group_id       = string<br/>    resource_ids   = optional(list(string))<br/>    resource_types = optional(list(string), ["serverless.function"])<br/>    levels         = optional(list(string), ["INFO"])<br/>    batch_cutoff   = number<br/>    batch_size     = number<br/>    stream_names   = optional(list(string))<br/>  })</pre> | <pre>{<br/>  "batch_cutoff": 1,<br/>  "batch_size": 1,<br/>  "group_id": null<br/>}</pre> | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory in megabytes for cloud function yc-function-example. | `number` | `128` | no |
-| <a name="input_message_queue"></a> [message\_queue](#input\_message\_queue) | Trigger type of message queue. | <pre>object({<br>    queue_id           = string<br>    service_account_id = optional(string)<br>    batch_cutoff       = number<br>    batch_size         = number<br>    visibility_timeout = optional(number, 600)<br>  })</pre> | <pre>{<br>  "batch_cutoff": 1,<br>  "batch_size": 1,<br>  "queue_id": null,<br>  "service_account_id": null<br>}</pre> | no |
+| <a name="input_message_queue"></a> [message\_queue](#input\_message\_queue) | Trigger type of message queue. | <pre>object({<br/>    queue_id           = string<br/>    service_account_id = optional(string)<br/>    batch_cutoff       = number<br/>    batch_size         = number<br/>    visibility_timeout = optional(number, 600)<br/>  })</pre> | <pre>{<br/>  "batch_cutoff": 1,<br/>  "batch_size": 1,<br/>  "queue_id": null,<br/>  "service_account_id": null<br/>}</pre> | no |
 | <a name="input_min_level"></a> [min\_level](#input\_min\_level) | Minimal level of logging for cloud function yc-function-example. | `string` | `"ERROR"` | no |
 | <a name="input_mount_bucket"></a> [mount\_bucket](#input\_mount\_bucket) | Mount bucket (true) or not (false). If `true` section `storage_mounts{}` should be defined. | `bool` | `false` | no |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | Cloud function's network id for VPC integration. | `string` | `null` | no |
-| <a name="input_object_storage"></a> [object\_storage](#input\_object\_storage) | Trigger type of object storage. | <pre>object({<br>    bucket_id    = string<br>    prefix       = optional(string)<br>    suffix       = optional(string)<br>    create       = optional(bool, true)<br>    update       = optional(bool, true)<br>    delete       = optional(bool, true)<br>    batch_cutoff = number<br>    batch_size   = number<br>  })</pre> | <pre>{<br>  "batch_cutoff": 1,<br>  "batch_size": 1,<br>  "bucket_id": null<br>}</pre> | no |
+| <a name="input_object_storage"></a> [object\_storage](#input\_object\_storage) | Trigger type of object storage. | <pre>object({<br/>    bucket_id    = string<br/>    prefix       = optional(string)<br/>    suffix       = optional(string)<br/>    create       = optional(bool, true)<br/>    update       = optional(bool, true)<br/>    delete       = optional(bool, true)<br/>    batch_cutoff = number<br/>    batch_size   = number<br/>  })</pre> | <pre>{<br/>  "batch_cutoff": 1,<br/>  "batch_size": 1,<br/>  "bucket_id": null<br/>}</pre> | no |
 | <a name="input_public_access"></a> [public\_access](#input\_public\_access) | Making cloud function public (true) or not (false). | `bool` | `false` | no |
 | <a name="input_retries_count"></a> [retries\_count](#input\_retries\_count) | Maximum number of retries for async invocation. | `number` | `3` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | Runtime for cloud function yc-function-example. | `string` | `"bash-2204"` | no |
-| <a name="input_scaling_policy"></a> [scaling\_policy](#input\_scaling\_policy) | List of scaling policies for cloud function yc-function-example. | <pre>list(object({<br>    tag                  = string<br>    zone_instances_limit = number<br>    zone_requests_limit  = number<br>  }))</pre> | n/a | yes |
-| <a name="input_storage_mounts"></a> [storage\_mounts](#input\_storage\_mounts) | Mounting s3 bucket. | <pre>object({<br>    mount_point_name = string<br>    bucket           = string<br>    prefix           = optional(string)<br>    read_only        = optional(bool, true)<br>  })</pre> | <pre>{<br>  "bucket": null,<br>  "mount_point_name": "yc-function"<br>}</pre> | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | List of tags for cloud function yc-function-example. | `list(string)` | <pre>[<br>  "yc_tag"<br>]</pre> | no |
-| <a name="input_timer"></a> [timer](#input\_timer) | Trigger type of timer. | <pre>object({<br>    cron_expression = optional(string, "*/30 * ? * * *")<br>    payload         = optional(string)<br>  })</pre> | <pre>{<br>  "cron_expression": "*/5 * ? * * *",<br>  "payload": null<br>}</pre> | no |
+| <a name="input_scaling_policy"></a> [scaling\_policy](#input\_scaling\_policy) | List of scaling policies for cloud function yc-function-example. | <pre>list(object({<br/>    tag                  = string<br/>    zone_instances_limit = number<br/>    zone_requests_limit  = number<br/>  }))</pre> | n/a | yes |
+| <a name="input_storage_mounts"></a> [storage\_mounts](#input\_storage\_mounts) | Mounting s3 bucket. | <pre>object({<br/>    mount_point_name = string<br/>    bucket           = string<br/>    prefix           = optional(string)<br/>    read_only        = optional(bool, true)<br/>  })</pre> | <pre>{<br/>  "bucket": null,<br/>  "mount_point_name": "yc-function"<br/>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | List of tags for cloud function yc-function-example. | `list(string)` | <pre>[<br/>  "yc_tag"<br/>]</pre> | no |
+| <a name="input_timer"></a> [timer](#input\_timer) | Trigger type of timer. | <pre>object({<br/>    cron_expression = optional(string, "*/30 * ? * * *")<br/>    payload         = optional(string)<br/>  })</pre> | <pre>{<br/>  "cron_expression": "*/5 * ? * * *",<br/>  "payload": null<br/>}</pre> | no |
 | <a name="input_use_async_invocation"></a> [use\_async\_invocation](#input\_use\_async\_invocation) | Use asynchronous invocation to message queue (true) or not (false). If `true`, parameters `ymq_success_target` and `ymq_failure_target` must be set. | `bool` | `false` | no |
-| <a name="input_use_existing_log_group"></a> [use\_existing\_log\_group](#input\_use\_existing\_log\_group) | Use existing logging group (true) or not (false).<br>    If `true` parameters `existing_log_group_id` must be set. | `bool` | `false` | no |
-| <a name="input_use_existing_sa"></a> [use\_existing\_sa](#input\_use\_existing\_sa) | Use existing service accounts (true) or not (false).<br>    If `true` parameters `existing_service_account_id` must be set. | `bool` | `false` | no |
-| <a name="input_user_hash"></a> [user\_hash](#input\_user\_hash) | User-defined string for current function version.<br>    User must change this string any times when function changed. <br>    Function will be updated when hash is changed." | `string` | `"yc-defined-string-for-tf-module"` | no |
+| <a name="input_use_existing_log_group"></a> [use\_existing\_log\_group](#input\_use\_existing\_log\_group) | Use existing logging group (true) or not (false).<br/>    If `true` parameters `existing_log_group_id` must be set. | `bool` | `false` | no |
+| <a name="input_use_existing_sa"></a> [use\_existing\_sa](#input\_use\_existing\_sa) | Use existing service accounts (true) or not (false).<br/>    If `true` parameters `existing_service_account_id` must be set. | `bool` | `false` | no |
+| <a name="input_user_hash"></a> [user\_hash](#input\_user\_hash) | User-defined string for current function version.<br/>    User must change this string any times when function changed.<br/>    Function will be updated when hash is changed." | `string` | `"yc-defined-string-for-tf-module"` | no |
 | <a name="input_yc_function_description"></a> [yc\_function\_description](#input\_yc\_function\_description) | Custom Cloud Function description from tf-module | `string` | `"yc-custom-function-description"` | no |
 | <a name="input_yc_function_name"></a> [yc\_function\_name](#input\_yc\_function\_name) | Custom Cloud Function name from tf-module | `string` | `"yc-custom-function-name"` | no |
 | <a name="input_ymq_failure_target"></a> [ymq\_failure\_target](#input\_ymq\_failure\_target) | Target for unsuccessful async invocation. | `string` | `null` | no |

--- a/example/example-2-wih-multiple-lockboxes/data.tf
+++ b/example/example-2-wih-multiple-lockboxes/data.tf
@@ -1,0 +1,15 @@
+data "yandex_lockbox_secret" "foo" {
+  name = "foo"
+}
+
+data "yandex_lockbox_secret_version" "foo" {
+  secret_id = data.yandex_lockbox_secret.foo.secret_id
+}
+
+data "yandex_lockbox_secret" "bar" {
+  name = "bar"
+}
+
+data "yandex_lockbox_secret_version" "bar" {
+  secret_id = data.yandex_lockbox_secret.bar.secret_id
+}

--- a/example/example-2-wih-multiple-lockboxes/main.tf
+++ b/example/example-2-wih-multiple-lockboxes/main.tf
@@ -38,5 +38,3 @@ module "cloud_function" {
     },
   ]
 }
-
-}

--- a/example/example-2-wih-multiple-lockboxes/main.tf
+++ b/example/example-2-wih-multiple-lockboxes/main.tf
@@ -1,0 +1,42 @@
+module "cloud_function" {
+  source = "../../"
+
+  # Cloud Function Definition
+  lockbox_secret_key   = var.lockbox_secret_key
+  lockbox_secret_value = var.lockbox_secret_value
+
+  zip_filename = "../../handler.zip"
+
+  # Cloud Function Scaling Policy Definition
+  scaling_policy = [{
+    tag                  = "yc_tag"
+    zone_instances_limit = 20
+    zone_requests_limit  = 20
+  }]
+
+  # Cloud Function Trigger Definition
+  choosing_trigger_type = "" # "logging"
+
+  logging = {
+    group_id     = "e23moaejmq8m74tssfu9"
+    batch_cutoff = 1
+    batch_size   = 1
+  }
+
+  existing_secrets = [
+    {
+      id                   = data.yandex_lockbox_secret.foo.secret_id
+      key                  = "password"
+      version_id           = data.yandex_lockbox_secret_version.foo.id
+      environment_variable = "FOO_PASSWORD"
+    },
+    {
+      id                   = data.yandex_lockbox_secret.bar.secret_id
+      key                  = "password"
+      version_id           = data.yandex_lockbox_secret_version.bar.id
+      environment_variable = "BAR_PASSWORD"
+    },
+  ]
+}
+
+}

--- a/example/example-2-wih-multiple-lockboxes/variables.tf
+++ b/example/example-2-wih-multiple-lockboxes/variables.tf
@@ -1,0 +1,19 @@
+resource "random_string" "unique_id" {
+  length  = 8
+  upper   = false
+  lower   = true
+  numeric = true
+  special = false
+}
+
+variable "lockbox_secret_key" {
+  description = "Lockbox secret key for cloud function yc-function-example."
+  type        = string
+  default     = null
+}
+
+variable "lockbox_secret_value" {
+  description = "Lockbox secret value for cloud function yc-function-example."
+  type        = string
+  default     = null
+}

--- a/example/example-2-wih-multiple-lockboxes/versions.tf
+++ b/example/example-2-wih-multiple-lockboxes/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    yandex = {
+      source  = "yandex-cloud/yandex"
+      version = ">= 0.107.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "> 3.3"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "> 0.9"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -205,7 +205,7 @@ resource "yandex_function_trigger" "yc_trigger" {
 
   function {
     id                 = yandex_function.yc_function.id
-    tag                = tolist(yandex_function.yc_function.tags)[0]
+    tag                = try(tolist(yandex_function.yc_function.tags)[0], null)
     service_account_id = local.create_sa ? var.existing_service_account_id : yandex_iam_service_account.default_cloud_function_sa[0].id
   }
 

--- a/main.tf
+++ b/main.tf
@@ -123,6 +123,16 @@ resource "yandex_function" "yc_function" {
     environment_variable = var.environment_variable
   }
 
+  dynamic "secrets" {
+    for_each = var.existing_secrets
+    content {
+      id                   = secrets.value.id
+      key                  = secrets.value.key
+      version_id           = secrets.value.version_id
+      environment_variable = secrets.value.environment_variable
+    }
+  }
+
   dynamic "async_invocation" {
     for_each = var.use_async_invocation != true ? [] : tolist(1)
     content {
@@ -195,7 +205,7 @@ resource "yandex_function_trigger" "yc_trigger" {
 
   function {
     id                 = yandex_function.yc_function.id
-    tag                = yandex_function.yc_function.tags[0]
+    tag                = tolist(yandex_function.yc_function.tags)[0]
     service_account_id = local.create_sa ? var.existing_service_account_id : yandex_iam_service_account.default_cloud_function_sa[0].id
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "tags" {
 variable "user_hash" {
   description = <<EOF
     User-defined string for current function version.
-    User must change this string any times when function changed. 
+    User must change this string any times when function changed.
     Function will be updated when hash is changed."
   EOF
   default     = "yc-defined-string-for-tf-module"
@@ -205,6 +205,17 @@ variable "lockbox_secret_key" {
 variable "lockbox_secret_value" {
   description = "Lockbox secret value for cloud function yc-function-example."
   type        = string
+}
+
+variable "existing_secrets" {
+  description = "list of existing Lockbox secrets values for cloud function."
+  type = list(object({
+    id                   = string
+    key                  = string
+    version_id           = string
+    environment_variable = string
+  }))
+  default = []
 }
 
 variable "environment_variable" {


### PR DESCRIPTION
Hi!

@SultankaReal @romati88  thanks for this module! 

I need some customisation for my case - use multiple lockboxes as secrets. In this PR i added support for this (see example)

And I had to change the code for the `yandex_function_trigger` resource because the linter crashed on the line 

`tag = yandex_function.yc_function.tags[0]`

```
Validation failed: .
╷
│ Error: Invalid index
│
│   on main.tf line 208, in resource "yandex_function_trigger" "yc_trigger":
│  208:     tag                = yandex_function.yc_function.tags[0]
│
│ Elements of a set are identified only by their value and don't have any
│ separate index or key to select with, so it's only possible to perform
│ operations across all elements of the set.
```